### PR TITLE
fix: recompile LST between PR and master runs

### DIFF
--- a/cmssw/run.sh
+++ b/cmssw/run.sh
@@ -97,6 +97,9 @@ if [ "$COMPARE_TO_MASTER" == "true" ]; then
   if ! [ -f bin/sdl ]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi
   cd $CMSSW_VERSION/src
   eval `scramv1 runtime -sh`
+  # Recompile LST in case anything changed in the headers
+  rm ../lib/${SCRAM_ARCH}/libRecoTrackerLST*
+  scram b -j 4
   echo "Running 21034.1 workflow..."
   cmsRun step3_RAW2DIGI_RECO_VALIDATION_DQM.py
   cmsRun step4_HARVESTING.py


### PR DESCRIPTION
When there are changes in the header files there can be issues when running the PR and master versions. This PR simply adds a step to recompile the LST part of CMSSW to fix these issues.