### PR TITLE
chore: upgrade to CMSSW 14_1_0_pre0

### DIFF
--- a/cmssw/run.sh
+++ b/cmssw/run.sh
@@ -14,7 +14,7 @@ fi
 # When using a non-default branch comparison plots are not made because the changes in both repos presumably depend on each other
 COMPARE_TO_MASTER=false
 if [ -z "$CMSSW_BRANCH" ] || [ "$CMSSW_BRANCH" == "default" ]; then
-  CMSSW_BRANCH=CMSSW_13_3_0_pre3_LST_X
+  CMSSW_BRANCH=CMSSW_14_1_0_pre0_LST_X
   COMPARE_TO_MASTER=true
 fi
 


### PR DESCRIPTION
I set the new default branch to be `CMSSW_14_1_0_pre0_LST_X` of the [CMSSW fork](https://github.com/SegmentLinking/cmssw). This was needed to match the switch to `CMSSW_14_1_0_pre0` in https://github.com/SegmentLinking/TrackLooper/pull/373.