### PR TITLE
fix: allow make clean errors

### DIFF
--- a/cmssw/run.sh
+++ b/cmssw/run.sh
@@ -91,7 +91,7 @@ if [ "$COMPARE_TO_MASTER" == "true" ]; then
   echo "Running setup script..."
   source setup.sh
   echo "Building and LST..."
-  make clean
+  make clean || echo "make clean failed"
   make code/rooutil/
   sdl_make_tracklooper -c || echo "Done"
   if ! [ -f bin/sdl ]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi

--- a/standalone/run.sh
+++ b/standalone/run.sh
@@ -26,7 +26,7 @@ git checkout origin/master
 echo "Running setup script..."
 source setup.sh
 echo "Building and LST..."
-make clean
+make clean || echo "make clean failed"
 make code/rooutil/
 sdl_make_tracklooper -cC || echo "Done"
 if ! [ -f bin/sdl ]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi


### PR DESCRIPTION
When there are changes in file names, `make clean` can fail to remove files. This shouldn't cause the CI to fail the job, so we need to allow `make clean` errors.