### PR TITLE
chore: minor tweaks and fixes

### DIFF
--- a/cmssw/run.sh
+++ b/cmssw/run.sh
@@ -45,7 +45,7 @@ git fetch SegLink ${CMSSW_BRANCH}:SegLink_cmssw
 git checkout SegLink_cmssw
 git fetch SegLink $CMSSW_DEFAULT_BRANCH
 git config user.email "gha@example.com" && git config user.name "GHA"
-git merge -m "Merge default branch" $CMSSW_DEFAULT_BRANCH || (echo "***\nError: There are merge conflicts that need to be resolved.\n***" && false)
+git merge -m "Merge default branch" SegLink/$CMSSW_DEFAULT_BRANCH || (echo "***\nError: There are merge conflicts that need to be resolved.\n***" && false)
 git cms-addpkg RecoTracker/LST Configuration/ProcessModifiers RecoTracker/ConversionSeedGenerators RecoTracker/FinalTrackSelectors RecoTracker/IterativeTracking
 cat <<EOF >lst_headers.xml
 <tool name="lst_headers" version="1.0">
@@ -108,7 +108,7 @@ if [ "$COMPARE_TO_MASTER" == "true" ]; then
   # Recompile CMSSW in case anything changed in the headers
   scram b clean
   # Go back to the default branch
-  git checkout $CMSSW_DEFAULT_BRANCH
+  git checkout SegLink/$CMSSW_DEFAULT_BRANCH
   scram b -j 4
   echo "Running 21034.1 workflow..."
   cmsRun step3_RAW2DIGI_RECO_VALIDATION_DQM.py

--- a/cmssw/run.sh
+++ b/cmssw/run.sh
@@ -31,9 +31,8 @@ git merge --no-commit --no-ff origin/master || (echo "***\nError: There are merg
 echo "Running setup script..."
 source setup.sh
 echo "Building and LST..."
-make code/rooutil/
-sdl_make_tracklooper -c || echo "Done"
-if ! [ -f bin/sdl ]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi
+sdl_make_tracklooper -mc || echo "Done"
+if [[ ! -f bin/sdl_cpu || ! -f bin/sdl_cuda ]]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi
 echo "Setting up CMSSW..."
 scramv1 project CMSSW $CMSSW_VERSION
 cd $CMSSW_VERSION/src
@@ -97,10 +96,8 @@ if [ "$COMPARE_TO_MASTER" == "true" ]; then
   echo "Running setup script..."
   source setup.sh
   echo "Building and LST..."
-  make clean || echo "make clean failed"
-  make code/rooutil/
-  sdl_make_tracklooper -c || echo "Done"
-  if ! [ -f bin/sdl ]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi
+  sdl_make_tracklooper -mcC || echo "Done"
+  if [[ ! -f bin/sdl_cpu ]]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi
   cd $CMSSW_VERSION/src
   eval `scramv1 runtime -sh`
   # Recompile CMSSW in case anything changed in the headers

--- a/standalone/run.sh
+++ b/standalone/run.sh
@@ -13,12 +13,10 @@ git merge --no-commit --no-ff origin/master || (echo "***\nError: There are merg
 echo "Running setup script..."
 source setup.sh
 echo "Building and LST..."
-make code/rooutil/
-sdl_make_tracklooper -c || echo "Done"
-if ! [ -f bin/sdl ]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi
+sdl_make_tracklooper -mc || echo "Done"
+if [[ ! -f bin/sdl_cpu || ! -f bin/sdl_cuda ]]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi
 echo "Running LST..."
-rm SDL/libsdl_cuda.so
-sdl -i PU200 -o LSTNtuple_after.root -s 4
+sdl_cpu -i PU200 -o LSTNtuple_after.root -s 4
 createPerfNumDenHists -i LSTNtuple_after.root -o LSTNumDen_after.root
 echo "Creating validation plots..."
 python3 efficiency/python/lst_plot_performance.py LSTNumDen_after.root -t "validation_plots"
@@ -32,12 +30,11 @@ git checkout origin/master
 echo "Running setup script..."
 source setup.sh
 echo "Building and LST..."
-make clean || echo "make clean failed"
-make code/rooutil/
-sdl_make_tracklooper -cC || echo "Done"
-if ! [ -f bin/sdl ]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi
+# Only CPU version is compiled since the master branch has already been tested
+sdl_make_tracklooper -mcC || echo "Done"
+if [[ ! -f bin/sdl_cpu ]]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi
 echo "Running LST..."
-sdl -i PU200 -o LSTNtuple_before.root -s 4
+sdl_cpu -i PU200 -o LSTNtuple_before.root -s 4
 createPerfNumDenHists -i LSTNtuple_before.root -o LSTNumDen_before.root
 # Go back to the PR commit so that the git tag is consistent everywhere
 git checkout $PRSHA


### PR DESCRIPTION
This PR contains the following changes:

- The makefile in the TrackLooper repo was recently fixed, so we no longer need to compile `rooutil` beforehand.
- Switched to using `sdl_cpu` instead of `sdl` so that we can remove the `sdl` symlink if we decide to do it.
- The default branch of the CMSSW repo is merged before running tests, so that changes made after the PR was opened are used.