### PR TITLE
feat: test ROCm compilation

### DIFF
--- a/cmssw/run.sh
+++ b/cmssw/run.sh
@@ -33,8 +33,7 @@ git merge --no-commit --no-ff origin/master || (echo "***\nError: There are merg
 echo "Running setup script..."
 source setup.sh
 echo "Building and LST..."
-sdl_make_tracklooper -mc || echo "Done"
-if [[ ! -f bin/sdl_cpu || ! -f bin/sdl_cuda ]]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi
+sdl_make_tracklooper -mcAs
 echo "Setting up CMSSW..."
 scramv1 project CMSSW $CMSSW_VERSION
 cd $CMSSW_VERSION/src
@@ -101,8 +100,7 @@ if [ "$COMPARE_TO_MASTER" == "true" ]; then
   echo "Running setup script..."
   source setup.sh
   echo "Building and LST..."
-  sdl_make_tracklooper -mcC || echo "Done"
-  if [[ ! -f bin/sdl_cpu ]]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi
+  sdl_make_tracklooper -mcCs
   cd $CMSSW_VERSION/src
   eval `scramv1 runtime -sh`
   # Recompile CMSSW in case anything changed in the headers

--- a/standalone/run.sh
+++ b/standalone/run.sh
@@ -13,8 +13,7 @@ git merge --no-commit --no-ff origin/master || (echo "***\nError: There are merg
 echo "Running setup script..."
 source setup.sh
 echo "Building and LST..."
-sdl_make_tracklooper -mc || echo "Done"
-if [[ ! -f bin/sdl_cpu || ! -f bin/sdl_cuda ]]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi
+sdl_make_tracklooper -mcAs
 echo "Running LST..."
 sdl_cpu -i PU200 -o LSTNtuple_after.root -s 4
 createPerfNumDenHists -i LSTNtuple_after.root -o LSTNumDen_after.root
@@ -31,8 +30,7 @@ echo "Running setup script..."
 source setup.sh
 echo "Building and LST..."
 # Only CPU version is compiled since the master branch has already been tested
-sdl_make_tracklooper -mcC || echo "Done"
-if [[ ! -f bin/sdl_cpu ]]; then echo "Build failed. Printing log..."; cat .make.log*; false; fi
+sdl_make_tracklooper -mcCs
 echo "Running LST..."
 sdl_cpu -i PU200 -o LSTNtuple_before.root -s 4
 createPerfNumDenHists -i LSTNtuple_before.root -o LSTNumDen_before.root


### PR DESCRIPTION
PRs are now compiled for all backends (now including ROCm), so we can make sure that there are no compile-time issues.